### PR TITLE
3 an endpoint to cancel a customers tea subscription

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::SubscriptionsController < ApplicationController
 
-  # POST /subscriptions
   def create
     customer = Customer.find(params[:customer_id])
     tea = Tea.find(params[:tea_id])
@@ -17,14 +16,18 @@ class Api::V1::SubscriptionsController < ApplicationController
   end
 
 
-  # DELETE /subscriptions/1
-  # def destroy
-  #   @subscription.destroy
-  # end
+  def destroy
+    @subscription = Subscription.find_by_id(params[:id])
+    if @subscription.destroy
+      render json: { message: 'Subscription deleted successfully' }, status: :ok
+    else
+      render json: { error: 'Failed to delete subscription' }, status: :unprocessable_entity
+    end
+  end
 
   private
 
     def subscription_params
       params.require(:subscription).permit(:title, :price, :status, :frequency)
     end
-end
+  end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,5 +1,13 @@
 class Subscription < ApplicationRecord
+  before_destroy :remove_subscription_teas
+
   belongs_to :customer
   has_many :subscription_teas
   has_many :teas, through: :subscription_teas
+
+  private
+
+  def remove_subscription_teas
+    self.teas.clear
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/customers', to: 'customers#index', as: :customers
       post '/customers/:customer_id/teas/:tea_id/subscribe', to: 'subscriptions#create', as: :subscribe_to_tea
+      delete '/customers/:customer_id/subscriptions/:id', to: 'subscriptions#destroy', as: :subscription
     end
   end
 end

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -26,4 +26,32 @@ RSpec.describe "/subscriptions", type: :request do
       expect(new_subscription.customer_id).to eq(customer.id)
     end
   end
+
+  describe "DELETE /destroy" do
+    let(:customer) { FactoryBot.create(:customer) }
+    let(:tea) { FactoryBot.create(:tea) }
+    let(:subscription_params) {
+      attributes = FactoryBot.attributes_for(:subscription).except(:tea_id)  # Remove the tea_id attribute
+      attributes.merge({customer_id: customer.id})
+    }
+    let(:subscription) {
+      sub = Subscription.new(subscription_params)
+      sub.customer = customer
+      sub.teas << tea
+      sub.save!
+      sub
+    }
+
+    it 'deletes a subscription and returns successful response' do
+      subscription
+      # require 'pry'; binding.pry
+      expect {
+        delete api_v1_subscription_path(customer_id: subscription.customer_id, id: subscription.id)
+      }.to change(Subscription, :count).by(-1)
+
+      expect(response).to be_successful
+      expect(Subscription.find_by(id: subscription.id)).to be_nil
+    end
+  end
+
 end


### PR DESCRIPTION
This PR:
- adds controller action for destroy
- adds AR callback to subscription model to destroy associated records in the SubscriptionTea join table
- adds route for DELETE
- adds test for subscription#destroy 