### PR TITLE
refact: add status validation to subscription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
-coverage/
+/coverage

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -5,6 +5,8 @@ class Subscription < ApplicationRecord
   has_many :subscription_teas
   has_many :teas, through: :subscription_teas
 
+  validates :status, inclusion: { in: %w[active cancelled] }
+
   private
 
   def remove_subscription_teas

--- a/db/migrate/20230919203745_update_status_on_subscriptions.rb
+++ b/db/migrate/20230919203745_update_status_on_subscriptions.rb
@@ -1,0 +1,5 @@
+class UpdateStatusOnSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    add_check_constraint :subscriptions, "status IN ('active', 'cancelled')", name: "check_status_on_subscriptions"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_18_171341) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_19_203745) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,6 +41,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_18_171341) do
     t.datetime "updated_at", null: false
     t.bigint "customer_id", null: false
     t.index ["customer_id"], name: "index_subscriptions_on_customer_id"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'cancelled'::character varying]::text[])", name: "check_status_on_subscriptions"
   end
 
   create_table "teas", force: :cascade do |t|


### PR DESCRIPTION
This PR
 - Added a validation to the subscription model to verify on active/cancelled status
 - Generated a migration to the subscription table to add a check constraint for the status
 - added /coverage to the .gitignore file